### PR TITLE
Fix: reduce memory consumption

### DIFF
--- a/nasl/src/cache.rs
+++ b/nasl/src/cache.rs
@@ -1,112 +1,22 @@
-use std::{
-    collections::HashMap,
-    sync::mpsc::{self, Receiver, Sender},
-    thread,
-    time::Duration,
-};
-use tracing::{debug, warn};
-use walkdir::WalkDir;
+use tracing::warn;
 
-use crate::{
-    interpret::{self, Interpret},
-    openvas_funcs,
-};
+use crate::openvas_funcs::OpenVASInterpreter;
 
 #[derive(Debug)]
 pub struct Cache {
-    paths: Vec<String>,
-    plugins: HashMap<String, Interpret>,
-    internal: Option<openvas_funcs::Interpreter>,
+    pub paths: Vec<String>,
+    internal: Option<OpenVASInterpreter>,
 }
 
 impl Cache {
-    fn load_plugins(paths: Vec<String>) -> HashMap<String, Interpret> {
-        let worker_count = num_cpus::get() * 10;
-        let (tx, rx) = mpsc::channel();
-        let mut children = Vec::new();
-        for _ in 0..worker_count {
-            let (txp, rxp): (Sender<String>, Receiver<String>) = mpsc::channel();
-            let ttx = tx.clone();
-            let child = thread::spawn(move || {
-                while let Ok(x) = rxp.recv_timeout(Duration::from_secs(1)) {
-                    match interpret::from_path(&x) {
-                        Ok((_, inter)) => {
-                            if let Err(err) = ttx.send((x.clone(), inter)) {
-                                warn!("unable to send {x} for caching: {err}");
-                            }
-                        }
-                        Err(err) => warn!("unable to create inter {x}: {err}"),
-                    }
-                }
-            });
-            children.push((txp, child));
-        }
-
-        let mut plugins = HashMap::new();
-        for path in paths {
-            let np = path.strip_prefix("file://").unwrap_or(&path);
-            debug!("looking for .nasl or .inc in {np}");
-            for (i, r) in WalkDir::new(np).follow_links(true).into_iter().enumerate() {
-                match r {
-                    Ok(entry) => {
-                        let fname = entry.path().to_string_lossy();
-                        if fname.ends_with(".inc") || fname.ends_with(".nasl") {
-                            if let Err(err) = children[i % worker_count].0.send(fname.to_string()) {
-                                warn!(
-                                    "unable to send {fname} to child {}: {err}",
-                                    i % worker_count
-                                );
-                            }
-                        }
-                    }
-                    Err(err) => warn!("unable to load file {err}"),
-                }
-            }
-        }
-        let stopped = || -> bool {
-            children
-                .iter()
-                .map(|(_, c)| c.is_finished())
-                .reduce(|p, n| p && n)
-                .unwrap_or(false)
-        };
-        while !stopped() {
-            while let Ok((p, i)) = rx.recv_timeout(Duration::from_millis(10)) {
-                plugins.insert(p, i);
-            }
-        }
-        plugins
-    }
-
     pub fn update_paths(&mut self, paths: Vec<String>) {
-        let plugins = Cache::load_plugins(paths.clone());
         self.paths.extend(paths);
-        self.plugins.extend(plugins);
-    }
-
-    pub fn count(&self) -> usize {
-        self.plugins.len()
     }
 
     pub fn new(paths: Vec<String>) -> Cache {
-        let plugins = Cache::load_plugins(paths.clone());
         Cache {
-            plugins,
             paths,
             internal: None,
-        }
-    }
-
-    pub fn update(&mut self, path: &str) -> Option<(String, Interpret)> {
-        match interpret::from_path(path) {
-            Ok((code, inter)) => {
-                self.plugins.insert(path.to_string(), inter.clone());
-                Some((code, inter))
-            }
-            Err(err) => {
-                warn!("unable to uypdate {path}: {err}");
-                None
-            }
         }
     }
 
@@ -116,30 +26,13 @@ impl Cache {
         } else {
             format!("{}/nasl/nasl_init.c", path)
         };
-        match openvas_funcs::Interpreter::from_path(&vp) {
+        match OpenVASInterpreter::from_path(&vp) {
             Ok(i) => self.internal = Some(i),
             Err(err) => warn!("enable to parse {path}: {err}"),
         }
     }
 
-    pub fn internal(&mut self) -> Option<openvas_funcs::Interpreter> {
+    pub fn internal(&mut self) -> Option<OpenVASInterpreter> {
         self.internal.clone()
-    }
-
-    pub fn get(self, path: &str) -> Option<Interpret> {
-        self.plugins.get(path).cloned()
-    }
-
-    pub fn find<'a>(&'a self, path: &'a str) -> impl Iterator<Item = (&String, &Interpret)> + 'a {
-        self.plugins.iter().filter_map(move |(k, v)| {
-            if k.ends_with(path) {
-                return Some((k, v));
-            }
-            None
-        })
-    }
-
-    pub fn each<'a>(&'a self) -> impl Iterator<Item = (&String, &Interpret)> + 'a {
-        self.plugins.iter()
     }
 }

--- a/nasl/src/lookup.rs
+++ b/nasl/src/lookup.rs
@@ -151,6 +151,10 @@ impl Lookup {
             includes,
         }
     }
+
+    pub fn origin(self) -> String {
+        self.definitions.origin
+    }
 }
 
 #[cfg(test)]

--- a/nasl/src/openvas_funcs.rs
+++ b/nasl/src/openvas_funcs.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct Interpreter {
+pub struct OpenVASInterpreter {
     definitions: DefContainer,
 }
 
@@ -70,13 +70,13 @@ pub trait DefResponseContainer<T> {
     fn items<'a>(&'a self, sp: &'a SearchParameter) -> Box<dyn Iterator<Item = Point> + '_>;
 }
 
-impl Interpreter {
-    pub fn from_path(path: &str) -> Result<Interpreter, Box<dyn Error>> {
+impl OpenVASInterpreter {
+    pub fn from_path(path: &str) -> Result<OpenVASInterpreter, Box<dyn Error>> {
         debug!("parsing {} for internal functions", path);
         let code = fs::read_to_string(path)?;
-        Interpreter::new(path.to_string(), code)
+        OpenVASInterpreter::new(path.to_string(), code)
     }
-    pub fn new(origin: String, code: String) -> Result<Interpreter, Box<dyn Error>> {
+    pub fn new(origin: String, code: String) -> Result<OpenVASInterpreter, Box<dyn Error>> {
         //let code = fs::read_to_string(path)?;
         let tree = tree(tree_sitter_c::language(), &code, None)?;
         let rn = tree.root_node();
@@ -97,7 +97,7 @@ impl Interpreter {
                 Jumpable::FunDef(id, vec![])
             }));
         }
-        Ok(Interpreter {
+        Ok(OpenVASInterpreter {
             definitions: DefContainer {
                 origin,
                 definitions,
@@ -119,7 +119,7 @@ mod tests {
 
     use crate::lookup::SearchParameter;
 
-    use super::Interpreter;
+    use super::OpenVASInterpreter;
 
     #[test]
     fn funcnames() {
@@ -128,7 +128,7 @@ mod tests {
         #include <stdio.h>
         static init_func libfuncs[] = { {"script_name", script_name_internal} };
         "#;
-        let ut = Interpreter::new("nasl_init.c".to_string(), code.to_string()).unwrap();
+        let ut = OpenVASInterpreter::new("nasl_init.c".to_string(), code.to_string()).unwrap();
         let sp = SearchParameter {
             origin: "nasl_init.c".to_string(),
             name: "script_name".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main_loop(
     let rrs = RequestResponseSender {
         connection: &connection,
     };
-    debug!("Initialized cache ({}) for {:?}", cache.count(), rp);
+    debug!("Initialized cache for {:?}", rp);
     for msg in &connection.receiver {
         match msg {
             Message::Request(req) => {


### PR DESCRIPTION
Instead of parsing every NASL plugin on load (can be up to 90k) it is
just parsing the includes and the root NASL plugin. With this change we
don't need to store a map with all information for a lookup table.

Currently tree-sitter is fast enough to not require threads for parallel
execution reducing the complexity of cache.rs significantly.
